### PR TITLE
Potential bug where classes that wrap an empty collection are still persisted.

### DIFF
--- a/src/main/java/com/foo/ListWrapper.java
+++ b/src/main/java/com/foo/ListWrapper.java
@@ -1,0 +1,32 @@
+package com.foo;
+
+import java.util.List;
+
+import dev.morphia.annotations.Entity;
+
+@Entity
+public class ListWrapper {
+  private List<String> data;
+
+  public ListWrapper() {
+  }
+
+  public ListWrapper(List<String> data) {
+    this.data = data;
+  }
+
+  public List<String> getData() {
+    return data;
+  }
+
+  public void setData(List<String> data) {
+    this.data = data;
+  }
+
+  @Override
+  public String toString() {
+    return "ListWrapper{" +
+        "data=" + data +
+        '}';
+  }
+}

--- a/src/main/java/com/foo/MyEntity.java
+++ b/src/main/java/com/foo/MyEntity.java
@@ -1,7 +1,56 @@
 package com.foo;
 
-import dev.morphia.annotations.Entity;
+import org.bson.types.ObjectId;
 
-@Entity
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+
+@Entity("MyEntityCollection")
 public class MyEntity {
+  @Id
+  private ObjectId id;
+  private String otherData;
+  private ListWrapper listWrapper;
+
+  public MyEntity() {
+  }
+
+  public MyEntity(ObjectId id, String otherData, ListWrapper listWrapper) {
+    this.id = id;
+    this.otherData = otherData;
+    this.listWrapper = listWrapper;
+  }
+
+  public ObjectId getId() {
+    return id;
+  }
+
+  public void setId(ObjectId id) {
+    this.id = id;
+  }
+
+  public String getOtherData() {
+    return otherData;
+  }
+
+  public void setOtherData(String otherData) {
+    this.otherData = otherData;
+  }
+
+  public ListWrapper getListWrapper() {
+    return listWrapper;
+  }
+
+  public void setListWrapper(ListWrapper listWrapper) {
+    this.listWrapper = listWrapper;
+  }
+
+  @Override
+  public String toString() {
+    return "MyEntity{" +
+        "id=" + id +
+        ", otherData='" + otherData + '\'' +
+        ", listWrapper=" + listWrapper +
+        '}';
+  }
 }

--- a/src/test/java/com/foo/ReproducerTest.java
+++ b/src/test/java/com/foo/ReproducerTest.java
@@ -52,7 +52,10 @@ public class ReproducerTest extends BottleRocketTest {
         MyEntity entity = new MyEntity(ObjectId.get(), "otherData", new ListWrapper(new ArrayList<>()));
         datastore.save(entity);
 
-        MyEntity foundEntity = datastore.find(MyEntity.class).filter(Filters.eq("id", entity.getId())).first();
+        MyEntity foundEntity = datastore.find(MyEntity.class).filter(Filters.eq("id", entity.getId()))
+            .filter(Filters.exists("listWrapper"))
+            .first();
+        assert foundEntity != null;
         assert foundEntity.getId().equals(entity.getId());
         // I would assume that this wouldn't be persisted, but I don't think this is happening right now.
         System.out.println(foundEntity);

--- a/src/test/java/com/foo/ReproducerTest.java
+++ b/src/test/java/com/foo/ReproducerTest.java
@@ -1,5 +1,7 @@
 package com.foo;
 
+import java.util.ArrayList;
+
 import com.antwerkz.bottlerocket.BottleRocket;
 import com.antwerkz.bottlerocket.BottleRocketTest;
 import com.github.zafarkhaja.semver.Version;
@@ -7,6 +9,11 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import dev.morphia.Datastore;
 import dev.morphia.Morphia;
+import dev.morphia.mapping.DiscriminatorFunction;
+import dev.morphia.mapping.MapperOptions;
+import dev.morphia.query.filters.Filters;
+
+import org.bson.types.ObjectId;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.testng.annotations.Test;
@@ -18,7 +25,14 @@ public class ReproducerTest extends BottleRocketTest {
         MongoClient mongo = getMongoClient();
         MongoDatabase database = getDatabase();
         database.drop();
-        datastore = Morphia.createDatastore(mongo, getDatabase().getName());
+        MapperOptions options = MapperOptions.builder()
+            .discriminator(DiscriminatorFunction.className())
+            .discriminatorKey("className")
+            .storeEmpties(false)
+            .storeNulls(false)
+            .build();
+        datastore = Morphia.createDatastore(mongo, getDatabase().getName(), options);
+        datastore.getMapper().map(MyEntity.class, ListWrapper.class);
     }
 
     @NotNull
@@ -35,6 +49,14 @@ public class ReproducerTest extends BottleRocketTest {
 
     @Test
     public void reproduce() {
+        MyEntity entity = new MyEntity(ObjectId.get(), "otherData", new ListWrapper(new ArrayList<>()));
+        datastore.save(entity);
+
+        MyEntity foundEntity = datastore.find(MyEntity.class).filter(Filters.eq("id", entity.getId())).first();
+        assert foundEntity.getId().equals(entity.getId());
+        // I would assume that this wouldn't be persisted, but I don't think this is happening right now.
+        System.out.println(foundEntity);
+        assert foundEntity.getListWrapper() == null;
     }
 
 }


### PR DESCRIPTION
Wanted to flag this, as it's different from how Morphia 1 behaves (at least Morphia 1.0.1 :/)

In Morphia 1, if the ListWrapper class that I've created wraps an empty or null list, the listWrapper itself will not be stored on the parent `MyEntity`. In Morphia 2, even if `storeEmpties` and `storeNulls` are set to false, MyEntity would be persisted, and the listWrapper field _does_ exist in the DB, as shown by the filter query. I'm wondering if this is intentional, or if it's a bug.